### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Audit
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/houseme/snowflake-rs/security/code-scanning/7](https://github.com/houseme/snowflake-rs/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the workflow root level, so it applies to all jobs unless overridden. In this case, the workflow only checks out code and runs an audit, so it only needs read access to repository contents. You should add the following block after the `name` and before the `on` section:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are needed. The change should be made in `.github/workflows/audit.yml`, at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
