### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
 
 name: Docs
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/houseme/snowflake-rs/security/code-scanning/6](https://github.com/houseme/snowflake-rs/security/code-scanning/6)

To fix the problem, explicitly set the `permissions` block to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and builds documentation, it does not need any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read repository contents (needed for `actions/checkout`). This block can be added at the workflow level (applies to all jobs) or at the job level (applies only to the `docs` job). The best practice is to add it at the workflow level, just after the `name` field and before `jobs:`.

**What to change:**  
- In `.github/workflows/docs.yml`, add the following block after the `name: Docs` line and before `jobs:`:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
